### PR TITLE
Add ARMADILLO dir to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 # prompt%> make CGM_BASE_DIR=/path/to/installed/cgm
 #
 # CGM_BASE_DIR = /path/to/installed/cgm
+# ARMADILLO_BASE_DIR = /path/to/installed/armadillo
 
 -include ${CGM_BASE_DIR}/lib/iGeom-Defs.inc
 
@@ -16,11 +17,11 @@ CXXSOURCES = mcnp2cad.cpp MCNPInput.cpp volumes.cpp geometry.cpp ProgOptions.cpp
 CXXOBJS = mcnp2cad.o MCNPInput.o volumes.o geometry.o ProgOptions.o
 
 # Remove HAVE_IGEOM_CONE from the next line if using old iGeom implementation
-CXXFLAGS = -g -std=c++11 -Wall -Wextra -DUSING_CGMA -DHAVE_IGEOM_CONE
+CXXFLAGS = -g -std=c++11 -Wall -Wextra -DUSING_CGMA -DHAVE_IGEOM_CONE -I${ARMADILLO_BASE_DIR}/include
 
 
 LDFLAGS = ${IGEOM_LIBS} 
-LDFLAGS += -larmadillo
+LDFLAGS += -L${ARMADILLO_BASE_DIR}/lib -larmadillo
 
 mcnp2cad: ${CXXOBJS} Makefile
 	${CXX} ${CXXFLAGS} -o $@ ${CXXOBJS} ${LDFLAGS}


### PR DESCRIPTION
Here's one way to do it for now.  I think a standard install will then work with
`ARMADILLO_BASE_DIR=/usr/local`
